### PR TITLE
Add Booking and Cancellation API Endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ import uvicorn
 from fastapi import FastAPI
 from app.database import engine
 from app.models import Base
+from app.routes import booking, cancel
 
 def create_app() -> FastAPI:
     """
@@ -14,6 +15,10 @@ def create_app() -> FastAPI:
     Base.metadata.create_all(bind=engine)
 
     app = FastAPI(title="Booking System API", version="0.1.0")
+
+    # Import the routes
+    app.include_router(booking.router, prefix="/api", tags=["Booking"])
+    app.include_router(cancel.router, prefix="/api", tags=["Cancellation"])
 
     return app
 

--- a/app/routes/booking.py
+++ b/app/routes/booking.py
@@ -1,13 +1,111 @@
-from fastapi import APIRouter, Depends, HTTPException
+"""
+This module defines the API routes for managing bookings using FastAPI.
+It includes endpoints for creating and canceling bookings, ensuring that
+all operations adhere to specified constraints.
+
+Routes:
+- POST /book: Create a new booking if constraints are met.
+
+Dependencies:
+- FastAPI's APIRouter for defining routes.
+- SQLAlchemy's Session for database interactions.
+- HTTPException and status for handling HTTP errors.
+- datetime for date and time operations.
+
+Models:
+- Member: Represents a member in the system.
+- Inventory: Represents an inventory item available for booking.
+- Booking: Represents a booking made by a member for an inventory item.
+
+Schemas:
+- BookingCreate: Schema for validating booking creation data.
+- BookingRead: Schema for returning booking details.
+
+Constraints:
+- A member can have a maximum of 2 active bookings.
+- An inventory item must have a remaining count greater than 0.
+- An inventory item must not be expired.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from .. import models, schemas, database
+from datetime import datetime
+
+from app.database import get_db
+from app.models import Member, Inventory, Booking
+from app.schemas import BookingCreate, BookingRead
 
 router = APIRouter()
 
-@router.post("/book", response_model=schemas.Booking)
-def create_booking(booking: schemas.BookingCreate, db: Session = Depends(database.SessionLocal)):
-    db_booking = models.Booking(**booking.dict())
-    db.add(db_booking)
+@router.post("/book", response_model=BookingRead)
+def create_booking(
+    booking_data: BookingCreate,
+    db: Session = Depends(get_db),
+):
+    """
+    Create a new booking if constraints are satisfied:
+    - Member has fewer than 2 active bookings
+    - Inventory has remaining_count > 0
+    """
+    # Fetch the Member & Inventory
+    member = db.query(Member).filter(Member.id == booking_data.member_id).first()
+    if not member:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Member with id={booking_data.member_id} not found."
+        )
+
+    inventory_item = db.query(Inventory).filter(Inventory.id == booking_data.inventory_id).first()
+    if not inventory_item:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Inventory item with id={booking_data.inventory_id} not found."
+        )
+
+    # Check constraints
+    # Member has < 2 active bookings
+    active_bookings_count = db.query(Booking).filter(
+        Booking.member_id == member.id,
+        Booking.is_active == True
+    ).count()
+
+    if active_bookings_count >= 2:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Member has reached the maximum of 2 active bookings."
+        )
+
+    # Inventory has remaining_count > 0
+    if inventory_item.remaining_count < 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No remaining count for this inventory item."
+        )
+
+    # Check if inventory is expired
+    # If today's date is past expiration_date, reject the booking
+    if inventory_item.expiration_date < datetime.utcnow().date():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Inventory item is expired; cannot be booked."
+        )
+
+    # Create the Booking
+    booking = Booking(
+        member_id=member.id,
+        inventory_id=inventory_item.id,
+        # is_active=True by default (set in models)
+        # booking_reference is auto-generated (UUID in models)
+    )
+    db.add(booking)
+
+    # Decrement the inventory count
+    inventory_item.remaining_count -= 1
+
+    # Increment the member booking_count
+    member.booking_count += 1
+
     db.commit()
-    db.refresh(db_booking)
-    return db_booking
+    db.refresh(booking)  # refresh to get the booking_reference, id, etc.
+
+    return booking

--- a/app/routes/cancel.py
+++ b/app/routes/cancel.py
@@ -1,14 +1,76 @@
-from fastapi import APIRouter, Depends, HTTPException
+"""
+This module defines the API route for canceling a booking in the application.
+
+The cancel_booking endpoint allows users to cancel an existing booking by providing
+a booking reference. Upon cancellation, the inventory count is incremented, the member's
+booking count is decremented, and the booking is marked as inactive.
+
+Models:
+- Member: Represents a member in the system.
+- Inventory: Represents an inventory item available for booking.
+- Booking: Represents a booking made by a member for an inventory item.
+
+Dependencies:
+- FastAPI for routing and HTTP exception handling.
+- SQLAlchemy ORM for database interactions.
+
+Routes:
+- POST /cancel: Cancel an existing booking by booking reference.
+
+Functions:
+- cancel_booking: Handles the cancellation of a booking and updates the relevant
+    inventory and member records in the database.
+
+Constraints:
+- The booking must be active to be canceled.
+- The inventory count is incremented upon cancellation.
+- The member's booking count is decremented upon cancellation.
+- The booking is marked as inactive after cancellation.
+
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from .. import models, schemas, database
+
+from app.database import get_db
+from app.models import Member, Inventory, Booking
+from app.schemas import BookingRead
 
 router = APIRouter()
 
-@router.delete("/cancel/{booking_id}", response_model=schemas.Booking)
-def cancel_booking(booking_id: int, db: Session = Depends(database.SessionLocal)):
-    db_booking = db.query(models.Booking).filter(models.Booking.id == booking_id).first()
-    if db_booking is None:
-        raise HTTPException(status_code=404, detail="Booking not found")
-    db.delete(db_booking)
+@router.post("/cancel", response_model=BookingRead)
+def cancel_booking(
+    booking_reference: str,
+    db: Session = Depends(get_db),
+):
+    """
+    Cancel an existing booking by booking_reference.
+    Increment the inventory count, decrement the member's booking count,
+    and mark is_active=False.
+    """
+    booking = db.query(Booking).filter(
+        Booking.booking_reference == booking_reference
+    ).first()
+
+    if not booking or not booking.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Active booking with this reference not found."
+        )
+
+    # Mark the booking as inactive
+    booking.is_active = False
+
+    # Restore the inventory count
+    inventory_item = db.query(Inventory).filter(Inventory.id == booking.inventory_id).first()
+    if inventory_item:
+        inventory_item.remaining_count += 1
+
+    # Decrement the member's booking_count
+    member = db.query(Member).filter(Member.id == booking.member_id).first()
+    if member and member.booking_count > 0:
+        member.booking_count -= 1
+
     db.commit()
-    return db_booking
+    db.refresh(booking)
+    return booking


### PR DESCRIPTION
This pull request introduces two FastAPI modules for managing bookings and cancellations. 
The booking.py module includes endpoints for creating new bookings with constraints on member and inventory statuses. The Cancel.py module provides functionality to cancel existing bookings, updating inventory and member booking counts accordingly.